### PR TITLE
Refuse instead of redirect

### DIFF
--- a/files/adservers_mkdb.sh
+++ b/files/adservers_mkdb.sh
@@ -16,7 +16,7 @@ unset LANG && \
     uniq | \
     { 
         while read -r site; do 
-            echo -e "local-data: \"${site} A 127.0.0.1\"\\nlocal-zone: \"${site}\" redirect";
+            echo -e "local-zone: \"${site}\" refuse";
         done
     } > /etc/adservers.db
 # OLD


### PR DESCRIPTION
Use refuse instead of redirect to lower ram usage and block-file size by about 50%.